### PR TITLE
Fixed regex dependency conflict

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -24,7 +24,7 @@ pymdown-extensions==8.1
 python-dateutil==2.8.1
 PyYAML==5.4.1
 rcslice==1.1.0
-regex==2020.11.13
+regex==2021.8.3
 six==1.15.0
 tornado==6.1
 tqdm==4.56.0


### PR DESCRIPTION
```
ERROR: Cannot install -r requirements.txt (line 19) and regex==2020.11.13 because these package versions have conflicting dependencies.

The conflict is caused by:
    The user requested regex==2020.11.13
    nltk 3.6.5 depends on regex>=2021.8.3
```